### PR TITLE
Enable access tokens for use with MAS authentication

### DIFF
--- a/src/entity/login.rs
+++ b/src/entity/login.rs
@@ -1,5 +1,12 @@
+use matrix_sdk::ruma::{OwnedDeviceId, OwnedUserId};
+
 pub enum Credentials {
     UserPassword(String, String),
+    AccessToken {
+        user_id: OwnedUserId,
+        device_id: OwnedDeviceId,
+        access_token: String,
+    },
 }
 
 pub struct Encryption {

--- a/src/init.rs
+++ b/src/init.rs
@@ -208,6 +208,33 @@ async fn login_and_recover(
                 }
             }
         }
+        LoginCredentials::AccessToken {
+            user_id,
+            device_id,
+            access_token,
+        } => {
+            use matrix_sdk::SessionMeta;
+            use matrix_sdk::SessionTokens;
+            use matrix_sdk::authentication::matrix::MatrixSession;
+
+            let session = MatrixSession {
+                meta: SessionMeta {
+                    user_id: user_id.clone(),
+                    device_id: device_id.clone(),
+                },
+                tokens: SessionTokens {
+                    access_token: access_token.clone(),
+                    refresh_token: None,
+                },
+            };
+
+            client
+                .restore_session(session)
+                .await
+                .map_err(LoginError::Auth)?;
+
+            tracing::info!("Authenticated via access token for {user_id}");
+        }
     }
 
     if let Some(encryption_config) = &login_config.encryption


### PR DESCRIPTION
I want to use https://github.com/etkecc/baibot with my set up, but it doesn't support access token login. Since that relies on this library, here's a fix to enable that.